### PR TITLE
feat(treasury): surface transaction expiry and policy invalidation in UI (#52)

### DIFF
--- a/frontend/src/app/treasury/page.tsx
+++ b/frontend/src/app/treasury/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useFreighter } from "@/context/FreighterProvider";
 import { useTreasury, TreasuryTransaction } from "@/hooks/useTreasury";
+import { useCountdown } from "@/hooks/useCountdown";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function TreasuryPage() {
@@ -40,6 +41,27 @@ export default function TreasuryPage() {
   } | null>(null);
 
   const [actionLoading, setActionLoading] = useState(false);
+
+  const Tooltip = ({ text, children }: { text: string; children: React.ReactNode }) => (
+    <div className="relative group">
+      {children}
+      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block z-50">
+        <div className="bg-gray-900 text-gray-200 text-xs rounded px-2 py-1 whitespace-nowrap border border-gray-700 shadow-lg">
+          {text}
+        </div>
+        <div className="border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900 w-0 h-0 mx-auto" />
+      </div>
+    </div>
+  );
+
+  const ExpiryCountdown = ({ expiresAt }: { expiresAt: number }) => {
+    const { formatted, isExpired } = useCountdown(expiresAt);
+    return (
+      <div className={`text-[11px] ${isExpired ? "text-orange-400 font-semibold" : "text-gray-500"}`}>
+        {isExpired ? "Expired" : formatted}
+      </div>
+    );
+  };
 
   const formatXLM = (stroops: number): string => {
     return (stroops / 10_000_000).toLocaleString(undefined, {
@@ -395,44 +417,68 @@ export default function TreasuryPage() {
                       </div>
                     </div>
 
-                    {/* Expiry metadata */}
-                    <div className="text-[11px] text-gray-500">
-                      Created: {new Date(tx.created_at * 1000).toLocaleString()} | Expires:{" "}
-                      {new Date(tx.expires_at * 1000).toLocaleString()}
-                    </div>
+                    {/* Expiry metadata with countdown */}
+                    <ExpiryCountdown expiresAt={tx.expires_at} />
                   </div>
 
                   {/* Actions */}
                   <div className="flex flex-wrap gap-2 w-full lg:w-auto">
                     {/* Approve button */}
-                    {status === "Pending" && isSigner(address) && !hasSigned && (
+                    {isSigner(address) && !hasSigned && (status === "Pending" ? (
                       <button
                         onClick={() => setPreviewAction({ type: "approve", tx })}
                         className="btn-primary text-xs py-1.5 px-3"
                       >
                         Sign Approval
                       </button>
-                    )}
+                    ) : (
+                      <Tooltip text={status === "Expired" ? "Transaction has expired" : "Policy invalidated — will not execute"}>
+                        <button
+                          disabled
+                          className="btn-primary text-xs py-1.5 px-3 opacity-40 cursor-not-allowed"
+                        >
+                          Sign Approval
+                        </button>
+                      </Tooltip>
+                    ))}
 
                     {/* Revoke button */}
-                    {status === "Pending" && isSigner(address) && hasSigned && (
+                    {isSigner(address) && hasSigned && (status === "Pending" ? (
                       <button
                         onClick={() => setPreviewAction({ type: "revoke", tx })}
                         className="px-3 py-1.5 bg-red-950/40 border border-red-900 text-red-400 hover:bg-red-900/40 rounded text-xs transition-colors"
                       >
                         Revoke Approval
                       </button>
-                    )}
+                    ) : (
+                      <Tooltip text={status === "Expired" ? "Transaction has expired" : "Policy invalidated — will not execute"}>
+                        <button
+                          disabled
+                          className="px-3 py-1.5 bg-red-950/40 border border-red-900 text-red-400 rounded text-xs opacity-40 cursor-not-allowed"
+                        >
+                          Revoke Approval
+                        </button>
+                      </Tooltip>
+                    ))}
 
                     {/* Execute button */}
-                    {status === "Ready" && (
+                    {(status === "Ready" ? (
                       <button
                         onClick={() => setPreviewAction({ type: "execute", tx })}
                         className="btn-primary text-xs py-1.5 px-4 bg-green-600 hover:bg-green-700 shadow-md shadow-green-600/25 border-green-800"
                       >
                         Execute Transfer
                       </button>
-                    )}
+                    ) : status === "Pending" && !isEligible ? null : (
+                      <Tooltip text={status === "Expired" ? "Transaction has expired" : "Policy invalidated — will not execute"}>
+                        <button
+                          disabled
+                          className="btn-primary text-xs py-1.5 px-4 bg-green-600 opacity-40 cursor-not-allowed border-green-800"
+                        >
+                          Execute Transfer
+                        </button>
+                      </Tooltip>
+                    ))}
 
                     {/* Cancel button */}
                     {(status === "Pending" || status === "Ready") &&

--- a/frontend/src/hooks/useCountdown.ts
+++ b/frontend/src/hooks/useCountdown.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useCountdown(targetTimestamp: number): {
+  remaining: number;
+  isExpired: boolean;
+  formatted: string;
+} {
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const target = targetTimestamp * 1000;
+  const remaining = Math.max(0, target - now);
+  const isExpired = remaining <= 0;
+
+  const totalSeconds = Math.floor(remaining / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const formatted = isExpired
+    ? "Expired"
+    : `${hours}h ${minutes}m ${seconds}s remaining`;
+
+  return { remaining, isExpired, formatted };
+}

--- a/frontend/tests/treasury.test.ts
+++ b/frontend/tests/treasury.test.ts
@@ -339,6 +339,62 @@ test("expiry invalidates approval and execution", () => {
   }, /expired/);
 });
 
+test("getProposalStatus derives correct status in priority order", () => {
+  const config: TreasuryConfig = {
+    admin: "GA_A",
+    threshold: 2,
+    signerCount: 3,
+    balance: 5000,
+    txCount: 1,
+    policyVersion: 2,
+  };
+
+  const baseTx = (overrides: Partial<TreasuryTransaction>): TreasuryTransaction => ({
+    id: 1,
+    to: "GA_DEST",
+    amount: 1000,
+    memo: "Test",
+    approvals: [],
+    executed: false,
+    canceled: false,
+    created_at: 100000,
+    expires_at: 200000,
+    proposer: "GA_A",
+    policy_version: 1,
+    ...overrides,
+  });
+
+  const getProposalStatus = (tx: TreasuryTransaction, cfg: TreasuryConfig | null, now: number) => {
+    if (tx.executed) return "Executed";
+    if (tx.canceled) return "Canceled";
+    if (now > tx.expires_at) return "Expired";
+    if (cfg && tx.policy_version !== cfg.policyVersion) return "Stale Policy";
+    if (cfg && tx.approvals.length >= cfg.threshold) return "Ready";
+    return "Pending";
+  };
+
+  // Executed takes priority
+  assert.equal(getProposalStatus(baseTx({ executed: true, canceled: true }), config, 150000), "Executed");
+
+  // Canceled takes priority over expired
+  assert.equal(getProposalStatus(baseTx({ canceled: true, expires_at: 1 }), config, 999999), "Canceled");
+
+  // Expired takes priority over stale policy and ready
+  assert.equal(getProposalStatus(baseTx({ expires_at: 100, approvals: ["GA_A", "GA_B"] }), config, 999999), "Expired");
+
+  // Stale policy takes priority over ready
+  assert.equal(getProposalStatus(baseTx({ approvals: ["GA_A", "GA_B"] }), config, 150000), "Stale Policy");
+
+  // Ready when threshold met
+  assert.equal(getProposalStatus(baseTx({ approvals: ["GA_A", "GA_B"], policy_version: 2 }), config, 150000), "Ready");
+
+  // Pending when no conditions match
+  assert.equal(getProposalStatus(baseTx({ policy_version: 2 }), config, 150000), "Pending");
+
+  // Null config returns Pending (edge case)
+  assert.equal(getProposalStatus(baseTx(), null, 150000), "Pending");
+});
+
 test("policy change invalidates pending proposals", () => {
   const configWithStalePolicy: TreasuryConfig = {
     admin: "GA_A",


### PR DESCRIPTION
Wire the frontend treasury dashboard to surface transaction expiry and policy-version invalidation to signers.

## Changes

1. **New `useCountdown` hook** — provides a live countdown to `expires_at` with formatted display and expiry detection.

2. **Countdown display** — replaces the static "Expires: ..." timestamp with a live countdown showing `Xh Ym Zs remaining` or "Expired" when past deadline.

3. **Disabled actions with tooltips** — instead of hiding Approve/Revoke/Execute buttons for expired or policy-invalidated transactions, they are now shown in a disabled state with an explanatory tooltip:
   - "Transaction has expired" for expired proposals
   - "Policy invalidated — will not execute" for stale policy proposals

4. **Unit test** — `getProposalStatus` state derivation test covering the full priority cascade (executed > canceled > expired > stale policy > ready > pending), including edge cases like null config.

## Related

Closes #52