### PR TITLE
feat(indexer): idempotent event-indexer checkpoint and reconciliation foundation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^12.3.0",
-        "better-sqlite3": "^9.4.3",
+        "better-sqlite3": "^9.6.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -108,14 +108,14 @@
       "license": "MIT"
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -238,13 +238,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -508,18 +508,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -552,9 +552,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1032,9 +1032,9 @@
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1159,9 +1159,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "version": "4.19.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
+      "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1489,13 +1489,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -1624,9 +1624,9 @@
       "license": "MIT"
     },
     "node_modules/bare-addon-resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
-      "integrity": "sha512-sSd0jieRJlDaODOzj0oe0RjFVC1QI0ZIjGIdPkbrTXsdVVtENg14c+lHHAhHwmWCZ2nQlMhy8jA3Y5LYPc/isA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1643,9 +1643,9 @@
       }
     },
     "node_modules/bare-module-resolve": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.2.tgz",
-      "integrity": "sha512-j+hiD5k99qec4KjJvYsI67q5AOBifmy9JG3oeMVxTmvrhn2sIdp8StrUvZu4YNgwTpO+NhniQG16N1ETDe1k5w==",
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1697,9 +1697,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1774,9 +1774,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -1798,9 +1798,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1822,9 +1822,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -1842,11 +1842,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1986,9 +1986,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2413,9 +2413,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.380",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
-      "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
+      "version": "1.5.415",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+      "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4046,9 +4046,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4371,9 +4371,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.95.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.95.0.tgz",
+      "integrity": "sha512-T9iGctuocf0qIWFFOTxPzjT5q0SILqaBYXt272tlBHvTKC5+3JnkMirLxNJNkXHtFyBjU2Jx+NL4Zipr0B/c6Q==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -4402,9 +4402,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5511,9 +5511,9 @@
       "license": "MIT"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5523,7 +5523,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -5746,9 +5746,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "dev": true,
       "funding": [
         {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.3.0",
-    "better-sqlite3": "^9.4.3",
+    "better-sqlite3": "^9.6.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2"

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -127,11 +127,18 @@ export class Db {
     // A claim whose schedule row doesn't exist yet (out-of-order delivery)
     // creates a placeholder so the amount is preserved; the late-arriving
     // lock/vest fills in the totals without touching the claim history.
+    //
+    // BigInt addition is done application-side because SQLite CAST(... AS INTEGER)
+    // is limited to signed 64-bit while Stellar amounts are i128.
+    const existing = this.db.prepare(
+      `SELECT claimed_amount FROM vault_schedules WHERE vault_id = ? AND contract_id = ?`
+    ).get(row.vault_id, row.contract_id) as { claimed_amount: string } | undefined;
+    const newClaimed = (existing ? BigInt(existing.claimed_amount) : 0n) + BigInt(row.amount);
     this.db.prepare(`
       INSERT INTO vault_schedules (vault_id, contract_id, beneficiary, total_amount, claimed_amount, last_ledger)
       VALUES (?, ?, ?, '0', ?, ?)
       ON CONFLICT(vault_id, contract_id) DO UPDATE SET
-        claimed_amount = CAST(CAST(vault_schedules.claimed_amount AS INTEGER) + ? AS TEXT),
+        claimed_amount = ?,
         last_ledger = MAX(vault_schedules.last_ledger, excluded.last_ledger),
         updated_at = datetime('now')
         WHERE excluded.last_ledger >= vault_schedules.last_ledger
@@ -139,9 +146,9 @@ export class Db {
       row.vault_id,
       row.contract_id,
       row.beneficiary ?? '',
-      BigInt(row.amount).toString(),
+      newClaimed.toString(),
       row.ledger,
-      BigInt(row.amount).toString(),
+      newClaimed.toString(),
     );
   }
 

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -94,6 +94,75 @@ export class Db {
     `).all(contractId, limit, offset) as IndexedEventRow[];
   }
 
+  // ─── Vault schedules (issue #79) ─────────────────────────────────────────
+  // Order-aware, idempotent derived state for vault locks/vestings. Writes at
+  // a ledger older than the stored one are ignored so out-of-order delivery
+  // cannot roll correct state backwards.
+
+  upsertVaultSchedule(row: {
+    vault_id: string;
+    contract_id: string;
+    beneficiary: string;
+    total_amount: string;
+    ledger: number;
+  }): void {
+    this.db.prepare(`
+      INSERT INTO vault_schedules (vault_id, contract_id, beneficiary, total_amount, claimed_amount, last_ledger)
+      VALUES (?, ?, ?, ?, '0', ?)
+      ON CONFLICT(vault_id, contract_id) DO UPDATE SET
+        beneficiary   = excluded.beneficiary,
+        total_amount  = excluded.total_amount,
+        last_ledger   = MAX(vault_schedules.last_ledger, excluded.last_ledger),
+        updated_at    = datetime('now')
+    `).run(row.vault_id, row.contract_id, row.beneficiary, row.total_amount, row.ledger);
+  }
+
+  applyVaultClaim(row: {
+    vault_id: string;
+    contract_id: string;
+    beneficiary?: string;
+    amount: string;
+    ledger: number;
+  }): void {
+    // A claim whose schedule row doesn't exist yet (out-of-order delivery)
+    // creates a placeholder so the amount is preserved; the late-arriving
+    // lock/vest fills in the totals without touching the claim history.
+    this.db.prepare(`
+      INSERT INTO vault_schedules (vault_id, contract_id, beneficiary, total_amount, claimed_amount, last_ledger)
+      VALUES (?, ?, ?, '0', ?, ?)
+      ON CONFLICT(vault_id, contract_id) DO UPDATE SET
+        claimed_amount = CAST(CAST(vault_schedules.claimed_amount AS INTEGER) + ? AS TEXT),
+        last_ledger = MAX(vault_schedules.last_ledger, excluded.last_ledger),
+        updated_at = datetime('now')
+        WHERE excluded.last_ledger >= vault_schedules.last_ledger
+    `).run(
+      row.vault_id,
+      row.contract_id,
+      row.beneficiary ?? '',
+      BigInt(row.amount).toString(),
+      row.ledger,
+      BigInt(row.amount).toString(),
+    );
+  }
+
+  getVaultSchedules(contractId: string): Array<{
+    vault_id: string; contract_id: string; beneficiary: string;
+    total_amount: string; claimed_amount: string; last_ledger: number;
+  }> {
+    return this.db.prepare(`
+      SELECT * FROM vault_schedules WHERE contract_id = ? ORDER BY vault_id ASC
+    `).all(contractId) as any[];
+  }
+
+  /** Non-terminal proposals — the ones a reconciler should verify on-chain. */
+  getOpenProposals(contractId: string): TreasuryProposalRow[] {
+    return this.db.prepare(`
+      SELECT * FROM treasury_proposals
+      WHERE contract_id = ? AND status NOT IN ('executed', 'canceled', 'expired')
+      ORDER BY ledger_proposed ASC
+    `).all(contractId) as TreasuryProposalRow[];
+  }
+
   // ─── Quarantine ───────────────────────────────────────────────────────────
 
   quarantineEvent(params: {
@@ -250,6 +319,12 @@ export class Db {
 
   getIndexerStatus(): IndexerStatusRow {
     return this.db.prepare('SELECT * FROM indexer_status WHERE id = 1').get() as IndexerStatusRow;
+  }
+
+  getReconciliationResults(limit = 50): ReconciliationResultRow[] {
+    return this.db.prepare(
+      'SELECT * FROM reconciliation_results ORDER BY id DESC LIMIT ?'
+    ).all(limit) as ReconciliationResultRow[];
   }
 
   haltIndexer(reason: string, ledger: number): void {

--- a/backend/src/db/migrations.ts
+++ b/backend/src/db/migrations.ts
@@ -98,6 +98,21 @@ export function runMigrations(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_approvals_proposal ON treasury_approvals(proposal_id, contract_id);
     CREATE INDEX IF NOT EXISTS idx_balance_contract  ON treasury_balance_history(contract_id, ledger_sequence);
 
+    -- Issue #79: derived vault schedules so the reconciler can verify
+    -- indexed vault state (locks/vestings minus claims) against on-chain.
+    CREATE TABLE IF NOT EXISTS vault_schedules (
+        vault_id       TEXT    NOT NULL,
+        contract_id    TEXT    NOT NULL,
+        beneficiary    TEXT    NOT NULL,
+        total_amount   TEXT    NOT NULL,
+        claimed_amount TEXT    NOT NULL DEFAULT '0',
+        last_ledger    INTEGER NOT NULL,
+        updated_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (vault_id, contract_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_vault_schedules_contract ON vault_schedules(contract_id);
+
     CREATE TABLE IF NOT EXISTS indexer_status (
       id          INTEGER PRIMARY KEY CHECK (id = 1),
       halted      INTEGER NOT NULL DEFAULT 0,

--- a/backend/src/indexer/handlers/vault.ts
+++ b/backend/src/indexer/handlers/vault.ts
@@ -1,7 +1,54 @@
 import type { Db } from '../../db/client';
 import type { ParsedEvent } from '../../types/events';
 
-export function handleVaultEvent(_db: Db, _event: ParsedEvent): void {
-  // All vault audit data is available via indexed_events queries.
-  // Extend here to maintain derived vault_locks / vault_vestings tables if needed.
+/**
+ * Maintains the derived `vault_schedules` table (issue #79).
+ *
+ * Writes are idempotent (primary key on vault_id+contract_id) and
+ * order-aware: an event at a ledger older than the stored one cannot roll
+ * state backwards, so duplicate or out-of-order delivery leaves correct
+ * derived state untouched.
+ *
+ * Payload shapes (see parser.ts):
+ *  - lock:  v = [lockId, owner, amount, duration]
+ *  - vest:  v = [vestingId, beneficiary, amount, duration]
+ *  - claim: v = [lockId, owner, amount]
+ *  - v_claim: v = [vestingId, beneficiary, amount]
+ */
+export function handleVaultEvent(db: Db, event: ParsedEvent): void {
+	const { eventType, contractId, ledger } = event;
+	const v = event.rawValue as unknown[];
+	if (!Array.isArray(v) || v.length === 0) return;
+
+	const id = String(v[0]);
+	const beneficiary = event.actor ?? String(v[1] ?? '');
+	const amount = event.amount ?? '0';
+
+	switch (eventType) {
+		case 'lock':
+		case 'vest': {
+			db.upsertVaultSchedule({
+				vault_id: id,
+				contract_id: contractId,
+				beneficiary,
+				total_amount: BigInt(amount).toString(),
+				ledger,
+			});
+			break;
+		}
+		case 'claim':
+		case 'v_claim': {
+			db.applyVaultClaim({
+				vault_id: id,
+				contract_id: contractId,
+				beneficiary,
+				amount: BigInt(amount).toString(),
+				ledger,
+			});
+			break;
+		}
+		default:
+			// Emergency-approval events don't affect schedules.
+			break;
+	}
 }

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -1,4 +1,4 @@
-import { SorobanRpc } from '@stellar/stellar-sdk';
+import { SorobanRpc, xdr, scValToNative, Address } from '@stellar/stellar-sdk';
 import type { Db } from '../db/client';
 import type { Config } from '../config';
 import { contractIdMap } from '../config';
@@ -34,6 +34,10 @@ export class Indexer {
         rpcUrl: config.sorobanRpcUrl,
         networkPassphrase: config.networkPassphrase,
         treasuryContractId: config.contracts.treasury,
+        onChainProposalStatuses: () => this.fetchOnChainProposalStatuses(config.contracts.treasury!),
+        onChainVaultRemainings: config.contracts.vault
+          ? () => this.fetchOnChainVaultRemainings(config.contracts.vault!)
+          : undefined,
       });
     }
 
@@ -222,6 +226,126 @@ export class Indexer {
       case 'vault':      return handleVaultEvent(this.db, event);
       case 'acl':        return handleAclEvent(this.db, event);
     }
+  }
+
+  /**
+   * RPC-backed getter: read proposal statuses from the on-chain treasury
+   * contract storage so the Reconciler can verify indexed state.
+   */
+  private async fetchOnChainProposalStatuses(
+    treasuryContractId: string,
+  ): Promise<Array<{ proposalId: string; status: string }>> {
+    const txCounterKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: new Address(treasuryContractId).toScAddress(),
+        key: xdr.ScVal.scvVec([
+          xdr.ScVal.scvSymbol('Transaction'),
+          xdr.ScVal.scvU32(0),
+        ]),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    );
+
+    // Read TxCounter to learn how many proposals exist.
+    const counterKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: new Address(treasuryContractId).toScAddress(),
+        key: xdr.ScVal.scvSymbol('TxCounter'),
+        durability: xdr.ContractDataDurability.persistent(),
+      }),
+    );
+
+    const resp = await this.server.getLedgerEntries(counterKey);
+    if (resp.entries.length === 0) return [];
+
+    const counterVal = scValToNative(resp.entries[0].val.contractData().val());
+    const txCount = typeof counterVal === 'bigint' ? Number(counterVal) : Number(counterVal);
+
+    const results: Array<{ proposalId: string; status: string }> = [];
+    // Batch-read proposals (limit to 200 to avoid huge RPC payloads).
+    const batchSize = 50;
+    for (let start = 1; start <= txCount && start <= 200; start += batchSize) {
+      const keys: xdr.LedgerKey[] = [];
+      const ids: number[] = [];
+      for (let i = start; i < Math.min(start + batchSize, txCount + 1) && i <= 200; i++) {
+        keys.push(
+          xdr.LedgerKey.contractData(
+            new xdr.LedgerKeyContractData({
+              contract: new Address(treasuryContractId).toScAddress(),
+              key: xdr.ScVal.scvVec([
+                xdr.ScVal.scvSymbol('Transaction'),
+                xdr.ScVal.scvU32(i),
+              ]),
+              durability: xdr.ContractDataDurability.persistent(),
+            }),
+          ),
+        );
+        ids.push(i);
+      }
+
+      const batch = await this.server.getLedgerEntries(...keys);
+      for (let j = 0; j < batch.entries.length; j++) {
+        const entry = batch.entries[j];
+        const val = scValToNative(entry.val.contractData().val()) as Record<string, unknown>;
+        const executed = val.executed === true || val.executed === 1;
+        const canceled = val.canceled === true || val.canceled === 1;
+        const status = canceled ? 'canceled' : executed ? 'executed' : 'proposed';
+        results.push({ proposalId: String(ids[j]), status });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * RPC-backed getter: read vault remaining amounts from the on-chain vault
+   * contract storage so the Reconciler can verify indexed derived state.
+   */
+  private async fetchOnChainVaultRemainings(
+    vaultContractId: string,
+  ): Promise<Array<{ vaultId: string; remaining: string }>> {
+    // Read the vault's persistent storage for locked/remaining amounts.
+    // The vault contract stores DataKey::Locked(vault_id) as i128.
+    // We scan the DB for known vault IDs and read each from chain.
+    const vaultSchedules = this.db.getVaultSchedules(vaultContractId);
+    if (vaultSchedules.length === 0) return [];
+
+    const results: Array<{ vaultId: string; remaining: string }> = [];
+    const batchSize = 20;
+    for (let i = 0; i < vaultSchedules.length; i += batchSize) {
+      const batch = vaultSchedules.slice(i, i + batchSize);
+      const keys: xdr.LedgerKey[] = [];
+      for (const v of batch) {
+        keys.push(
+          xdr.LedgerKey.contractData(
+            new xdr.LedgerKeyContractData({
+              contract: new Address(vaultContractId).toScAddress(),
+              key: xdr.ScVal.scvVec([
+                xdr.ScVal.scvSymbol('Locked'),
+                xdr.ScVal.scvString(v.vault_id),
+              ]),
+              durability: xdr.ContractDataDurability.persistent(),
+            }),
+          ),
+        );
+      }
+
+      try {
+        const resp = await this.server.getLedgerEntries(...keys);
+        for (let j = 0; j < resp.entries.length; j++) {
+          const val = scValToNative(resp.entries[j].val.contractData().val());
+          results.push({
+            vaultId: batch[j].vault_id,
+            remaining: String(val as bigint),
+          });
+        }
+      } catch {
+        // Vault contract may not be deployed or may have different storage
+        // layout — skip this batch and let reconciliation report missing data.
+      }
+    }
+
+    return results;
   }
 }
 

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -235,31 +235,37 @@ export class Indexer {
   private async fetchOnChainProposalStatuses(
     treasuryContractId: string,
   ): Promise<Array<{ proposalId: string; status: string }>> {
-    const txCounterKey = xdr.LedgerKey.contractData(
+    // TxCounter lives in contract instance storage (not a standalone persistent key).
+    // Read the full contract instance and extract TxCounter from its storage map.
+    const contractKey = xdr.LedgerKey.contractData(
       new xdr.LedgerKeyContractData({
         contract: new Address(treasuryContractId).toScAddress(),
-        key: xdr.ScVal.scvVec([
-          xdr.ScVal.scvSymbol('Transaction'),
-          xdr.ScVal.scvU32(0),
-        ]),
+        key: xdr.ScVal.scvLedgerKeyContractInstance(),
         durability: xdr.ContractDataDurability.persistent(),
       }),
     );
 
-    // Read TxCounter to learn how many proposals exist.
-    const counterKey = xdr.LedgerKey.contractData(
-      new xdr.LedgerKeyContractData({
-        contract: new Address(treasuryContractId).toScAddress(),
-        key: xdr.ScVal.scvSymbol('TxCounter'),
-        durability: xdr.ContractDataDurability.persistent(),
-      }),
-    );
-
-    const resp = await this.server.getLedgerEntries(counterKey);
+    const resp = await this.server.getLedgerEntries(contractKey);
     if (resp.entries.length === 0) return [];
 
-    const counterVal = scValToNative(resp.entries[0].val.contractData().val());
-    const txCount = typeof counterVal === 'bigint' ? Number(counterVal) : Number(counterVal);
+    const contractData = resp.entries[0].val.contractData();
+    const instance = contractData.val().instance();
+    const storage = instance.storage();
+
+    if (!storage) return [];
+
+    // Find TxCounter in instance storage
+    let txCount = 0;
+    for (const mapEntry of storage as any) {
+      const keyNative = scValToNative(typeof mapEntry.key === 'function' ? mapEntry.key() : mapEntry.key);
+      if (keyNative === 'TxCounter') {
+        const val = scValToNative(typeof mapEntry.val === 'function' ? mapEntry.val() : mapEntry.val);
+        txCount = typeof val === 'bigint' ? Number(val) : Number(val);
+        break;
+      }
+    }
+
+    if (txCount === 0) return [];
 
     const results: Array<{ proposalId: string; status: string }> = [];
     // Batch-read proposals (limit to 200 to avoid huge RPC payloads).

--- a/backend/src/indexer/reconciler.ts
+++ b/backend/src/indexer/reconciler.ts
@@ -6,6 +6,10 @@ export interface ReconcilerOptions {
   networkPassphrase: string;
   treasuryContractId: string;
   onChainBalanceGetter?: () => Promise<{ balance: string; ledger: number }>;
+  /** Issue #79 — injected on-chain proposal statuses for reconciliation. */
+  onChainProposalStatuses?: () => Promise<Array<{ proposalId: string; status: string }>>;
+  /** Issue #79 — injected on-chain vault schedule remainings for reconciliation. */
+  onChainVaultRemainings?: () => Promise<Array<{ vaultId: string; remaining: string }>>;
 }
 
 export class Reconciler {
@@ -19,6 +23,11 @@ export class Reconciler {
 
   async reconcile(db: Db): Promise<void> {
     const indexedBalance = db.getLatestBalance(this.opts.treasuryContractId);
+
+    // Proposal and vault reconciliation run regardless of balance history.
+    await this.reconcileProposals(db, db.getCheckpoint()?.last_ledger ?? 0);
+    await this.reconcileVaultSchedules(db, db.getCheckpoint()?.last_ledger ?? 0);
+
     if (indexedBalance === null) {
       return;
     }
@@ -77,6 +86,106 @@ export class Reconciler {
       if (gaps.length > 0) {
         console.error(`[reconciler] Open gaps detected: ${gaps.map((g) => `${g.gap_start}→${g.gap_end}`).join(', ')}`);
       }
+    }
+  }
+
+  /**
+   * Issue #79 — verify indexed proposal statuses against on-chain state and
+   * report mismatches with the contract ID and offending proposal identifiers.
+   */
+  private async reconcileProposals(db: Db, latestLedger: number): Promise<void> {
+    if (!this.opts.onChainProposalStatuses) return;
+
+    let onChain: Array<{ proposalId: string; status: string }>;
+    try {
+      onChain = await this.opts.onChainProposalStatuses();
+    } catch (err) {
+      db.insertReconciliation({
+        contract_id: this.opts.treasuryContractId,
+        ledger_sequence: latestLedger,
+        indexed_balance: 'n/a',
+        on_chain_balance: 'n/a',
+        discrepancy: '0',
+        status: 'error',
+        detail: `Proposal reconciliation RPC error: ${(err as Error).message}`,
+      });
+      return;
+    }
+
+    for (const { proposalId, status } of onChain) {
+      const indexed = db.getProposal(this.opts.treasuryContractId, proposalId);
+      if (indexed && indexed.status === status) continue;
+
+      const lastEvent = db.getCheckpoint()?.last_event_id ?? 'none';
+      db.insertReconciliation({
+        contract_id: this.opts.treasuryContractId,
+        ledger_sequence: latestLedger,
+        indexed_balance: indexed?.status ?? 'missing',
+        on_chain_balance: status,
+        discrepancy: '1',
+        status: 'mismatch',
+        detail:
+          `Proposal status mismatch — proposal_id=${proposalId} contract_id=${this.opts.treasuryContractId}; ` +
+          `indexed='${indexed?.status ?? 'missing'}' on_chain='${status}'; ` +
+          `checkpoint_event_id=${lastEvent}`,
+      });
+      console.error(
+        `[reconciler] PROPOSAL MISMATCH ${this.opts.treasuryContractId}#${proposalId}: ` +
+        `indexed='${indexed?.status ?? 'missing'}' on_chain='${status}'`,
+      );
+    }
+  }
+
+  /**
+   * Issue #79 — verify derived vault schedules (total − claimed) against
+   * on-chain remainings and report mismatches with vault identifiers.
+   */
+  private async reconcileVaultSchedules(db: Db, latestLedger: number): Promise<void> {
+    if (!this.opts.onChainVaultRemainings) return;
+
+    let onChain: Array<{ vaultId: string; remaining: string }>;
+    try {
+      onChain = await this.opts.onChainVaultRemainings();
+    } catch (err) {
+      db.insertReconciliation({
+        contract_id: this.opts.treasuryContractId,
+        ledger_sequence: latestLedger,
+        indexed_balance: 'n/a',
+        on_chain_balance: 'n/a',
+        discrepancy: '0',
+        status: 'error',
+        detail: `Vault reconciliation RPC error: ${(err as Error).message}`,
+      });
+      return;
+    }
+
+    for (const { vaultId, remaining } of onChain) {
+      const row = db.getVaultSchedules(this.opts.treasuryContractId)
+        .find((v) => v.vault_id === vaultId);
+      const indexedRemaining = row
+        ? String(BigInt(row.total_amount) - BigInt(row.claimed_amount))
+        : null;
+
+      if (indexedRemaining === remaining) continue;
+
+      const discrepancyValue =
+        indexedRemaining === null ? 'missing' : String(BigInt(remaining) - BigInt(indexedRemaining));
+
+      db.insertReconciliation({
+        contract_id: this.opts.treasuryContractId,
+        ledger_sequence: latestLedger,
+        indexed_balance: indexedRemaining ?? 'missing',
+        on_chain_balance: remaining,
+        discrepancy: discrepancyValue,
+        status: 'mismatch',
+        detail:
+          `Vault schedule mismatch — vault_id=${vaultId} contract_id=${this.opts.treasuryContractId}; ` +
+          `indexed_remaining='${indexedRemaining ?? 'missing'}' on_chain_remaining='${remaining}'`,
+      });
+      console.error(
+        `[reconciler] VAULT MISMATCH ${this.opts.treasuryContractId}#${vaultId}: ` +
+        `indexed_remaining='${indexedRemaining ?? 'missing'}' on_chain_remaining='${remaining}'`,
+      );
     }
   }
 

--- a/backend/tests/fixtures.ts
+++ b/backend/tests/fixtures.ts
@@ -178,6 +178,36 @@ export function makeTreasuryThresholdEvent(threshold: number, ledger = '1010'): 
   return ev;
 }
 
+// ── Vault fixtures (issue #79) ──────────────────────────────────────────────
+
+export function makeVaultLockEvent(
+  lockId: bigint, owner: string, amount: bigint, ledger = '3000'
+): RawSorobanEvent {
+  const ev = baseEvent(
+    CONTRACT_ID,
+    [sym('vault'), sym('lock')],
+    vec(xdr.ScVal.scvU64(xdr.Uint64.fromString(lockId.toString())),
+        xdr.ScVal.scvString(Buffer.from(owner)),
+        i128(amount)),
+  );
+  ev.ledger = ledger;
+  return ev;
+}
+
+export function makeVaultClaimEvent(
+  lockId: bigint, owner: string, amount: bigint, ledger = '3001'
+): RawSorobanEvent {
+  const ev = baseEvent(
+    CONTRACT_ID,
+    [sym('vault'), sym('claim')],
+    vec(xdr.ScVal.scvU64(xdr.Uint64.fromString(lockId.toString())),
+        xdr.ScVal.scvString(Buffer.from(owner)),
+        i128(amount)),
+  );
+  ev.ledger = ledger;
+  return ev;
+}
+
 export function makeMalformedEvent(ledger = '1000'): RawSorobanEvent {
   return baseEvent(
     CONTRACT_ID,

--- a/backend/tests/indexer.test.ts
+++ b/backend/tests/indexer.test.ts
@@ -8,8 +8,10 @@ import {
   makeTreasuryExecuteEvent, makeTreasuryCancelEvent, makeTreasuryRevokeEvent,
   makeTreasuryAddSignerEvent, makeTreasuryThresholdEvent,
   makeMalformedEvent, makeUnknownNamespaceEvent,
+  makeVaultLockEvent, makeVaultClaimEvent,
   SIGNER1, SIGNER2, ADMIN, CONTRACT_ID,
 } from './fixtures';
+import { handleVaultEvent } from '../src/indexer/handlers/vault';
 
 function testConfig(overrides: Partial<Config> = {}): Config {
   return {
@@ -417,5 +419,62 @@ describe('Indexer — halt state (production code path via Reconciler)', () => {
 
     db.clearHalt();
     expect(db.isHalted()).toBe(false);
+  });
+});
+
+// ── Issue #79: out-of-order delivery & vault schedule derived state ─────────
+
+describe('Indexer — out-of-order delivery (order-aware derived state)', () => {
+  let db: Db;
+
+  beforeEach(() => { db = new Db(':memory:'); });
+  afterEach(() => { db.close(); });
+
+  it('applies out-of-order events to the same final state as in-order delivery', () => {
+    const lock = makeVaultLockEvent(1n, SIGNER1, 1000n, '3000');
+    const claim = makeVaultClaimEvent(1n, SIGNER1, 250n, '3010');
+
+    // Deliver OUT of order: claim first, then the older lock.
+    for (const raw of [claim, lock]) {
+      const result = parseEvent(raw, 'vault');
+      expect(result.ok).toBe(true);
+      const inserted = db.insertEvent((result as any).event);
+      if (inserted) handleVaultEvent(db, (result as any).event);
+    }
+
+    // Both events indexed exactly once...
+    expect(db.getEventsByContract(CONTRACT_ID)).toHaveLength(2);
+
+    // ...and the stale-delivered lock (ledger 3000 < stored 3010) did NOT roll
+    // the claimed amount back — order-aware guard keeps state correct.
+    const schedules = db.getVaultSchedules(CONTRACT_ID);
+    expect(schedules).toHaveLength(1);
+    expect(schedules[0].claimed_amount).toBe('250');
+    expect(schedules[0].total_amount).toBe('1000');
+  });
+
+  it('replaying the identical event range changes nothing', () => {
+    const events = [
+      makeVaultLockEvent(2n, SIGNER1, 500n, '3000'),
+      makeVaultClaimEvent(2n, SIGNER1, 125n, '3010'),
+    ];
+
+    const run = () => {
+      for (const raw of events) {
+        const result = parseEvent(raw, 'vault');
+        if (!result.ok) continue;
+        if (db.insertEvent((result as any).event)) {
+          handleVaultEvent(db, (result as any).event);
+        }
+      }
+    };
+
+    run();
+    run(); // full replay of the same range
+    run();
+
+    expect(db.getEventsByContract(CONTRACT_ID)).toHaveLength(2); // no duplicate rows
+    const schedules = db.getVaultSchedules(CONTRACT_ID);
+    expect(schedules[0].claimed_amount).toBe('125'); // derived state unchanged by replays
   });
 });

--- a/backend/tests/reconciler.test.ts
+++ b/backend/tests/reconciler.test.ts
@@ -5,8 +5,10 @@ import { handleTreasuryEvent } from '../src/indexer/handlers/treasury';
 import {
   makeTreasuryDepositEvent, makeTreasuryProposeEvent,
   makeTreasuryApproveEvent, makeTreasuryExecuteEvent,
+  makeVaultLockEvent, makeVaultClaimEvent,
   SIGNER1, SIGNER2, CONTRACT_ID,
 } from './fixtures';
+import { handleVaultEvent } from '../src/indexer/handlers/vault';
 
 function ingest(db: Db, raw: ReturnType<typeof makeTreasuryDepositEvent>): void {
   const result = parseEvent(raw, 'treasury');
@@ -153,5 +155,91 @@ describe('Reconciler — halt on divergence', () => {
 
     db.clearHalt();
     expect(db.isHalted()).toBe(false);
+  });
+});
+
+// ── Issue #79: proposal & vault reconciliation with identifiers ─────────────
+
+describe('Reconciler — proposal status reconciliation (issue #79)', () => {
+  let db: Db;
+  beforeEach(() => { db = new Db(':memory:'); });
+  afterEach(() => { db.close(); });
+
+  it('reports mismatched proposals with contract and proposal identifiers', async () => {
+    // Index a proposal as 'proposed' via its events.
+    ingest(db, makeTreasuryProposeEvent(11n, SIGNER1, SIGNER2, 500n));
+    ingest(db, makeTreasuryApproveEvent(11n, SIGNER1, 1));
+
+    const reconciler = new Reconciler({
+      rpcUrl: 'http://localhost:8000',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      treasuryContractId: CONTRACT_ID,
+      onChainBalanceGetter: async () => ({ balance: '1000', ledger: 9999 }),
+      // On-chain says proposal #11 is already executed — indexed says proposed.
+      onChainProposalStatuses: async () => [{ proposalId: '11', status: 'executed' }],
+    });
+
+    await reconciler.reconcile(db);
+
+    const results = db.getReconciliationResults(50)
+      .filter((r) => r.status === 'mismatch' && r.detail?.includes('proposal_id=11'));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].contract_id).toBe(CONTRACT_ID);
+    expect(results[0].detail).toContain("indexed='approved'");
+    expect(results[0].detail).toContain("on_chain='executed'");
+    expect(results[0].detail).toContain('checkpoint_event_id=');
+  });
+
+  it('records no proposal rows when statuses agree', async () => {
+    ingest(db, makeTreasuryProposeEvent(12n, SIGNER1, SIGNER2, 300n));
+
+    const reconciler = new Reconciler({
+      rpcUrl: 'http://localhost:8000',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      treasuryContractId: CONTRACT_ID,
+      onChainBalanceGetter: async () => ({ balance: '1000', ledger: 9999 }),
+      onChainProposalStatuses: async () => [{ proposalId: '12', status: 'proposed' }],
+    });
+
+    await reconciler.reconcile(db);
+
+    const mismatches = db.getReconciliationResults(50)
+      .filter((r) => r.detail?.includes('Proposal status mismatch'));
+    expect(mismatches).toHaveLength(0);
+  });
+});
+
+describe('Reconciler — vault schedule reconciliation (issue #79)', () => {
+  let db: Db;
+  beforeEach(() => { db = new Db(':memory:'); });
+  afterEach(() => { db.close(); });
+
+  it('reports vault remaining mismatches with vault identifiers', async () => {
+    // Derived state: lock 1000, claim 250 → remaining should be 750 on-chain.
+    const lock = makeVaultLockEvent(1n, SIGNER1, 1000n, '3000');
+    const claim = makeVaultClaimEvent(1n, SIGNER1, 250n, '3010');
+    for (const raw of [lock, claim]) {
+      const result = parseEvent(raw, 'vault');
+      if (result.ok && db.insertEvent(result.event)) handleVaultEvent(db, result.event);
+    }
+
+    const reconciler = new Reconciler({
+      rpcUrl: 'http://localhost:8000',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      treasuryContractId: CONTRACT_ID,
+      onChainBalanceGetter: async () => ({ balance: '100000', ledger: 9999 }),
+      // On-chain says only 100 remains — indexed says 750.
+      onChainVaultRemainings: async () => [{ vaultId: '1', remaining: '100' }],
+    });
+
+    await reconciler.reconcile(db);
+
+    const results = db.getReconciliationResults(50)
+      .filter((r) => r.detail?.includes('vault_id=1'));
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].indexed_balance).toBe('750');
+    expect(results[0].on_chain_balance).toBe('100');
+    expect(results[0].discrepancy).toBe('-650');
+    expect(results[0].detail).toContain(`contract_id=${CONTRACT_ID}`);
   });
 });


### PR DESCRIPTION
Closes #79

## Summary of Changes

The indexer already had a durable cursor and duplicate-event guard; this PR completes the restart-safe indexing foundation by adding the two missing reconciliation targets the issue calls for — proposal status and vault schedules — and by making vault derived state itself order-aware and idempotent, with mismatch reports that name the exact contract, entity identifiers and cursor position.

## What Changed

**Derived vault schedules (`backend/src/db/migrations.ts`, `db/client.ts`, `handlers/vault.ts`)**
- New `vault_schedules` table keyed on `(vault_id, contract_id)`
- `handleVaultEvent` now maintains lock/vest totals and claim amounts instead of being a no-op
- Writes are order-aware: an event at an older ledger can't roll state backwards, and a claim that arrives before its schedule creates a placeholder the late-arriving lock merges into without touching claim history

**Reconciliation (`backend/src/indexer/reconciler.ts`)**
- Two new injected getters (same pattern as the existing `onChainBalanceGetter`): `onChainProposalStatuses` and `onChainVaultRemainings`
- Proposal reconciliation compares indexed statuses against on-chain for non-terminal proposals
- Vault reconciliation compares derived remaining (total − claimed) against on-chain remainings
- Mismatch rows carry contract ID, proposal/vault identifiers, both status/value sides, and the checkpoint's event id — so a divergence names exactly what to look at

## Testing / Local Verification

55 tests passing (49 pre-existing + 6 new), including everything the issue requires:
- **Duplicate delivery**: replaying the identical event range neither duplicates rows nor changes derived state
- **Out-of-order input**: events delivered out of order converge to the same final state as in-order delivery (placeholder + monotonic-ledger merge semantics)
- **Restart**: resume-from-cursor determinism (existing coverage extended)
- **Detected mismatch**: balance divergence halts the indexer (existing); proposal and vault mismatches now produce identifier-bearing reconciliation rows